### PR TITLE
Making links in README non-relative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Features & Backlog
 License
 -------
 
-[New BSD](COPYING)
+[New BSD](https://github.com/blue-yonder/devpi-builder/blob/master/COPYING)


### PR DESCRIPTION
With relative links, PyPI does not correctly render the README:
https://pypi.python.org/pypi/devpi-builder/