### PR TITLE
Use release junit-xml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools==18.0.1
 wheel==0.24.0
 pip==7.1.0
 six==1.9.0
-https://github.com/kyrus/python-junit-xml/tarball/master
+junit-xml==1.6
 
 setuptools_scm
 nose


### PR DESCRIPTION
We used to use the master of junit-xml, as release 1.3 did not work on Python 3. As later releases do we can now switch back.