### PR TITLE
Capture build errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg
+.eggs
 *.egg-info
 .idea
 .coverage

--- a/devpi_builder/wheeler.py
+++ b/devpi_builder/wheeler.py
@@ -64,7 +64,7 @@ class Builder(object):
                 '--wheel-dir=' + self.wheelhouse,
                 '--build=' + self.builddir,
                 '{}=={}'.format(package, version)
-            ])
+            ], stderr=subprocess.STDOUT)
             return self._find_wheel(package, version)
         except subprocess.CalledProcessError as e:
             raise BuildError(package, version, e)


### PR DESCRIPTION
This redirects stderr to stdout so errors aren't quite so cryptic in the event of a build failure.

This also updates .gitignore to ignore .eggs (which get populated after a `python setup.py develop`).