### PR TITLE
Add the command line parameter `--run-id`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ This lists the most important changes for each release.
 Unreleased
 ==========
 
+Added
+-----
+
+* The command line parameter ``--run-id`` allows to specify a run identifier that will be added to each entry in the
+  generated JUnit XML.
+
 Changed
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Commandline Usage
 ::
 
     usage: devpi-builder [-h] [--blacklist BLACKLIST] [--pure-index PURE_INDEX]
-                         [--junit-xml JUNIT_XML] [--dry-run]
+                         [--junit-xml JUNIT_XML] [--run-id RUN_ID] [--dry-run]
                          [--client-cert CLIENT_CERT]
                          requirements index user password
 
@@ -63,6 +63,8 @@ Commandline Usage
       --junit-xml JUNIT_XML
                             Write information about the build success / failure to
                             a JUnit-compatible XML file.
+      --run-id RUN_ID       Add the given run identifier entries in the XML
+                            output.
       --dry-run             Build missing wheels, but do not modify the state of
                             the devpi server.
       --client-cert CLIENT_CERT

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,9 @@ Commandline Usage
       --junit-xml JUNIT_XML
                             Write information about the build success / failure to
                             a JUnit-compatible XML file.
-      --run-id RUN_ID       Add the given run identifier entries in the XML
-                            output.
+      --run-id RUN_ID       Add the given string to all entries in the XML output,
+                            allowing to distinguish output from multiple runs in a
+                            merged XML.
       --dry-run             Build missing wheels, but do not modify the state of
                             the devpi server.
       --client-cert CLIENT_CERT

--- a/devpi_builder/cli.py
+++ b/devpi_builder/cli.py
@@ -105,7 +105,7 @@ def main(args=None):
                                              'pure index will not be built, either.'
     )
     parser.add_argument('--junit-xml', help='Write information about the build success / failure to a JUnit-compatible XML file.')
-    parser.add_argument('--run-id', help='Add the given run identifier entries in the XML output.')
+    parser.add_argument('--run-id', help='Add the given string to all entries in the XML output, allowing to distinguish output from multiple runs in a merged XML.')
     parser.add_argument('--dry-run', help='Build missing wheels, but do not modify the state of the devpi server.', action='store_true')
     parser.add_argument('--client-cert', help='Client key to use to authenticate with the devpi server.', default=None)
 


### PR DESCRIPTION
If `--run-id` is set, the given value will be added to each entry in the generated JUnit XML report. This can be useful if a package if build results from several runs on different operating systems or Python version are combined.