### PR TITLE
Upgrade requirements to get build on Travis working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+env:
+- DEVPI_PLUMBER_SERVER_HOST=127.0.0.1
 sudo: false
 install:
 - pip install -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -7,4 +7,3 @@ pytest-cov
 pytest-mock
 mock
 devpi-plumber[test]
-devpi-server<4.3.0  # TODO remove once devpi-plumber supports higher versions

--- a/requirements.in
+++ b/requirements.in
@@ -6,4 +6,4 @@ pytest
 pytest-cov
 pytest-mock
 mock
-devpi-plumber[test]
+devpi-plumber[test]>=0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,16 +6,16 @@
 #
 apipkg==1.4               # via execnet
 argon2-cffi==16.3.0       # via passlib
-certifi==2017.7.27.1      # via requests
-cffi==1.10.0              # via argon2-cffi
+certifi==2017.11.5        # via requests
+cffi==1.11.2              # via argon2-cffi
 chardet==3.0.4            # via requests
 check-manifest==0.35      # via devpi-client
-coverage==4.4.1           # via pytest-cov
+coverage==4.4.2           # via pytest-cov
 devpi-client==3.0.0       # via devpi-plumber
 devpi-common==3.1.0       # via devpi-client, devpi-server
-devpi-plumber[test]==0.4.2
-devpi-server==4.2.1
-execnet==1.4.1            # via devpi-server
+devpi-plumber[test]==0.4.3
+devpi-server==4.3.0       # via devpi-plumber
+execnet==1.5.0            # via devpi-server
 hupper==1.0               # via pyramid
 idna==2.6                 # via requests
 itsdangerous==0.24        # via devpi-server
@@ -26,20 +26,20 @@ pastedeploy==1.5.2        # via plaster-pastedeploy, pyramid
 pbr==3.1.1                # via mock
 pkginfo==1.4.1            # via devpi-client
 plaster-pastedeploy==0.4.1  # via pyramid
-plaster==0.5              # via plaster-pastedeploy, pyramid
+plaster==1.0              # via plaster-pastedeploy, pyramid
 pluggy==0.5.2             # via devpi-server, tox
-py==1.4.34                # via devpi-client, devpi-common, devpi-server, pytest, tox
+py==1.5.0                 # via devpi-client, devpi-common, devpi-server, pytest, tox
 pycparser==2.18           # via cffi
 pyramid==1.9.1            # via devpi-server
 pytest-cov==2.5.1
-pytest-mock==1.6.2
-pytest-runner==2.12.1
-pytest==3.2.2
+pytest-mock==1.6.3
+pytest-runner==3.0
+pytest==3.2.5
 repoze.lru==0.7           # via devpi-server, pyramid
 requests==2.18.4          # via devpi-common
 setuptools-scm==1.15.6
-six==1.10.0               # via argon2-cffi, devpi-plumber, junit-xml, mock
-tox==2.8.1                # via devpi-client
+six==1.11.0               # via argon2-cffi, devpi-plumber, junit-xml, mock, tox
+tox==2.9.1                # via devpi-client
 translationstring==1.3    # via pyramid
 twitter.common.contextutil==0.3.9  # via devpi-plumber
 twitter.common.dirutil==0.3.9  # via twitter.common.contextutil
@@ -47,11 +47,11 @@ twitter.common.lang==0.3.9  # via twitter.common.dirutil
 urllib3==1.22             # via requests
 venusian==1.1.0           # via pyramid
 virtualenv==15.1.0        # via tox
-waitress==1.0.2           # via devpi-server
+waitress==1.1.0           # via devpi-server
 webob==1.7.3              # via pyramid
-wheel==0.29.0
+wheel==0.30.0
 zope.deprecation==4.3.0   # via pyramid
-zope.interface==4.4.2     # via pyramid
+zope.interface==4.4.3     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'pytest-runner',
         'mock',
         'devpi-plumber[test]',
-        'devpi-server<4.3.0',  # TODO remove once devpi-plumber supports higher versions
     ],
     test_suite='pytest-runner',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pytest-cov',
         'pytest-runner',
         'mock',
-        'devpi-plumber[test]',
+        'devpi-plumber[test]>=0.4.3',
     ],
     test_suite='pytest-runner',
     classifiers=[


### PR DESCRIPTION
Without the updates the Devpi server tries to bind to IPv6 and fails doing so.