### PR TITLE
Avoid wheel 0.32

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ This lists the most important changes for each release.
 UNRELEASED
 ==========
 
+Fixed
+-----
+
+* Correctly specify the dependency to Wheel to avoid the latest, incompatible versions.
+
 Removed
 -------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,59 +5,64 @@
 #    pip-compile --no-index --output-file requirements.txt requirements.in
 #
 apipkg==1.5               # via execnet
-argon2-cffi==18.1.0       # via passlib
-atomicwrites==1.1.5       # via pytest
-attrs==18.1.0             # via pytest
-certifi==2018.4.16        # via requests
+appdirs==1.4.3            # via devpi-server
+argon2-cffi==18.3.0       # via passlib
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
+certifi==2018.10.15       # via requests
 cffi==1.11.5              # via argon2-cffi
 chardet==3.0.4            # via requests
 check-manifest==0.37      # via devpi-client
 coverage==4.5.1           # via pytest-cov
-devpi-client==4.0.3       # via devpi-plumber
-devpi-common==3.2.3       # via devpi-client, devpi-server
-devpi-plumber[test]==0.4.3
-devpi-server==4.6.0       # via devpi-plumber
+devpi-client==4.1.0       # via devpi-plumber
+devpi-common==3.3.1       # via devpi-client, devpi-server
+devpi-plumber[test]==0.5.0
+devpi-server==4.7.1       # via devpi-plumber
 execnet==1.5.0            # via devpi-server
-hupper==1.3               # via pyramid
+filelock==3.0.9           # via tox
+hupper==1.4               # via pyramid
 idna==2.7                 # via requests
-itsdangerous==0.24        # via devpi-server
+itsdangerous==1.1.0       # via devpi-server
 junit-xml==1.8
 mock==2.0.0
-more-itertools==4.2.0     # via pytest
-packaging==17.1           # via tox
+more-itertools==4.3.0     # via pytest
 passlib[argon2]==1.7.1    # via devpi-server
 pastedeploy==1.5.2        # via plaster-pastedeploy, pyramid
-pbr==4.1.0                # via mock
+pathlib2==2.3.2           # via pytest
+pbr==5.1.0                # via mock
 pkginfo==1.4.2            # via devpi-client
 plaster-pastedeploy==0.6  # via pyramid
 plaster==1.0              # via plaster-pastedeploy, pyramid
-pluggy==0.6.0             # via devpi-client, devpi-server, pytest, tox
-py==1.5.4                 # via devpi-client, devpi-common, devpi-server, pytest, tox
-pycparser==2.18           # via cffi
-pyparsing==2.2.0          # via packaging
+pluggy==0.8.0             # via devpi-client, devpi-server, pytest, tox
+py==1.7.0                 # via devpi-client, devpi-common, devpi-server, pytest, tox
+pycparser==2.19           # via cffi
 pyramid==1.9.2            # via devpi-server
-pytest-cov==2.5.1
+pytest-cov==2.6.0
 pytest-mock==1.10.0
 pytest-runner==4.2
-pytest==3.6.3
+pytest==3.9.3
+python-dateutil==2.7.5    # via strictyaml
 repoze.lru==0.7           # via devpi-server, pyramid
-requests==2.19.1          # via devpi-common
-setuptools-scm==2.1.0
-six==1.11.0               # via argon2-cffi, devpi-plumber, junit-xml, mock, more-itertools, packaging, pytest, tox
-tox==3.1.2                # via devpi-client
+requests==2.20.0          # via devpi-common
+ruamel.yaml==0.15.75      # via strictyaml
+setuptools-scm==3.1.0
+six==1.11.0               # via argon2-cffi, devpi-plumber, junit-xml, mock, more-itertools, pathlib2, pytest, python-dateutil, tox
+strictyaml==0.14.1        # via devpi-server
+toml==0.10.0              # via tox
+tox==3.5.3                # via devpi-client
 translationstring==1.3    # via pyramid
 twitter.common.contextutil==0.3.9  # via devpi-plumber
 twitter.common.dirutil==0.3.9  # via twitter.common.contextutil
 twitter.common.lang==0.3.9  # via twitter.common.dirutil
-urllib3==1.23             # via requests
+urllib3==1.24             # via requests
 venusian==1.1.0           # via pyramid
 virtualenv==16.0.0        # via tox
 waitress==1.1.0           # via devpi-server
-webob==1.8.2              # via pyramid
+webob==1.8.3              # via pyramid
 wheel==0.31.1
 zope.deprecation==4.3.0   # via pyramid
-zope.interface==4.5.0     # via pyramid
+zope.interface==4.6.0     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
-# setuptools                # via plaster, pyramid, pytest, zope.deprecation, zope.interface
+# setuptools                # via plaster, pyramid, pytest, tox, zope.deprecation, zope.interface

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'devpi-plumber>=0.2.14',
         'setuptools',
-        'wheel',
+        'wheel<0.32',
         'pip>=1.5.3',
         'junit-xml'
     ],


### PR DESCRIPTION
This is just an ugly workaround for the fact that Wheel changed it's
API with version 0.32 and we cannot trivially adjust to this.