### PR TITLE
fix: Adhere to case-insensivity in 'matched_by_list'

### DIFF
--- a/devpi_builder/requirements.py
+++ b/devpi_builder/requirements.py
@@ -61,7 +61,7 @@ def matched_by_list(package, version, requirements):
     version = pkg_resources.safe_version('{}'.format(version))
     package = pkg_resources.safe_name(package)
     matches = (
-        package == requirement.project_name and version in requirement
+        package.lower() == requirement.key and version in requirement
         for requirement in requirements
     )
     return any(matches)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -49,6 +49,7 @@ def test_matched_by_list():
     assert not requirements.matched_by_list('at_least_0_5', 0.4, parsed)
 
     assert requirements.matched_by_list('below_2_0', 1.0, parsed)
+    assert requirements.matched_by_list('Below_2_0', 1.0, parsed)
     assert not requirements.matched_by_list('below_2_0', 2.0, parsed)
 
 


### PR DESCRIPTION
This will lead to e.g. blacklisting 'cython' and 'Cython' being the same thing.