### PR TITLE
Disable the PyUp bot

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,3 @@
 ---
 
-update: insecure
-schedule: "every day"
+update: False


### PR DESCRIPTION
We already get security updates from Dependabot. There is no need to have each PR twice.