### PR TITLE
Fix build with setuptools-scm >= 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+addopts = "--cov-report= --cov=devpi_builder tests"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [tool:pytest]
 addopts = --cov-report= --cov=devpi_builder tests
-
-[aliases]
-test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-addopts = --cov-report= --cov=devpi_builder tests

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ setup(
     license='new BSD',
     install_requires=requirements,
     python_requires='>=3.8',
-    setup_requires=[
-        'setuptools_scm',
-    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
This moves the build from using the deprecated `setup_requires` declaration to specifying build dependencies as specified in PEP 517.

This should fix the build issues that PR #210 has been running into.